### PR TITLE
First approach: Public IPv4

### DIFF
--- a/ffhh.conf
+++ b/ffhh.conf
@@ -33,6 +33,14 @@ zone "112.10.in-addr.arpa" IN {
     allow-update { key srv01-zone-key.; };
 };
 
+#The reverse Zone for our public IPv4 subnet
+zone "224.96.193.in-addr.arpa" IN {
+    type master;
+    file "/etc/bind/master/db.arpa.in-addr.193.96.224";
+    allow-transfer { any; };
+    allow-update { key srv01-zone-key.; };
+};
+
 #And the reverse Zone for our IPv6 prefix
 zone "7.6.2.2.3.0.a.2.ip6.arpa" IN {
     type master;

--- a/ffhh.conf
+++ b/ffhh.conf
@@ -39,6 +39,8 @@ zone "224.96.193.in-addr.arpa" IN {
     file "/etc/bind/master/db.arpa.in-addr.193.96.224";
     allow-transfer { any; };
     allow-update { key srv01-zone-key.; };
+    notify yes;
+    also-notify { 213.128.128.33; };
 };
 
 #And the reverse Zone for our IPv6 prefix

--- a/master/db.arpa.in-addr.193.96.224
+++ b/master/db.arpa.in-addr.193.96.224
@@ -1,0 +1,70 @@
+$ORIGIN 224.96.193.in-addr.arpa.
+$TTL 86400	; 1 Tag
+@			IN SOA	srv01.hamburg.freifunk.net. hostmaster.hamburg.ccc.de. (
+				2015060400; serial: wird bei jeder Aenderung inkrementiert (Format: JJJJMMTTVV)
+				86400	; refresh: Sekundenabstand, in dem die Slaves anfragen, ob sich etwas geändert hat
+				7200	; retry: Sekundenabstand, in denen ein Slave wiederholt, falls sein Master nicht antwortet
+				3600000	; expire: wenn der Master auf einen Zonentransfer-Request nicht reagiert, deaktiviert ein Slave nach dieser Zeitspanne in Sekunden die Zone
+				172800	; TTL fuer negatives caching: Analog zum Standard-Caching wird im Cache vermerkt, dass dem zuständigen Nameserver der Name unbekannt war. Da für einen nicht vorhandenen Namen keine TTL existiert, steht sie hier.
+				)
+
+
+; AUTHORATIVE NAMESERVER
+@                       NS      srv01.hamburg.freifunk.net.
+
+
+; Dienste. Fuers Erste Adressen zwischen .240 und .255 nehmen (/28er-Netz)
+242			PTR	srv02.hamburg.freifunk.net.
+
+
+; Client-NAT-Bloecke
+
+; GW01
+0			PTR	nat-0-gw01.hamburg.freifunk.net.
+1			PTR	nat-1-gw01.hamburg.freifunk.net.
+2			PTR	nat-2-gw01.hamburg.freifunk.net.
+3			PTR	nat-3-gw01.hamburg.freifunk.net.
+4			PTR	nat-4-gw01.hamburg.freifunk.net.
+5			PTR	nat-5-gw01.hamburg.freifunk.net.
+6			PTR	nat-6-gw01.hamburg.freifunk.net.
+7			PTR	nat-7-gw01.hamburg.freifunk.net.
+
+; GW02
+8			PTR	nat-8-gw02.hamburg.freifunk.net.
+9			PTR	nat-9-gw02.hamburg.freifunk.net.
+10			PTR	nat-10-gw02.hamburg.freifunk.net.
+11			PTR	nat-11-gw02.hamburg.freifunk.net.
+12			PTR	nat-12-gw02.hamburg.freifunk.net.
+13			PTR	nat-13-gw02.hamburg.freifunk.net.
+14			PTR	nat-14-gw02.hamburg.freifunk.net.
+15			PTR	nat-15-gw02.hamburg.freifunk.net.
+
+; GW03
+16			PTR	nat-16-gw03.hamburg.freifunk.net.
+17			PTR	nat-17-gw03.hamburg.freifunk.net.
+18			PTR	nat-18-gw03.hamburg.freifunk.net.
+19			PTR	nat-19-gw03.hamburg.freifunk.net.
+20			PTR	nat-20-gw03.hamburg.freifunk.net.
+21			PTR	nat-21-gw03.hamburg.freifunk.net.
+22			PTR	nat-22-gw03.hamburg.freifunk.net.
+23			PTR	nat-23-gw03.hamburg.freifunk.net.
+
+; GW05
+24			PTR	nat-24-gw05.hamburg.freifunk.net.
+25			PTR	nat-25-gw05.hamburg.freifunk.net.
+26			PTR	nat-26-gw05.hamburg.freifunk.net.
+27			PTR	nat-27-gw05.hamburg.freifunk.net.
+28			PTR	nat-28-gw05.hamburg.freifunk.net.
+29			PTR	nat-29-gw05.hamburg.freifunk.net.
+30			PTR	nat-30-gw05.hamburg.freifunk.net.
+31			PTR	nat-31-gw05.hamburg.freifunk.net.
+
+; GW08
+32			PTR	nat-32-gw08.hamburg.freifunk.net.
+33			PTR	nat-33-gw08.hamburg.freifunk.net.
+34			PTR	nat-34-gw08.hamburg.freifunk.net.
+35			PTR	nat-35-gw08.hamburg.freifunk.net.
+36			PTR	nat-36-gw08.hamburg.freifunk.net.
+37			PTR	nat-37-gw08.hamburg.freifunk.net.
+38			PTR	nat-38-gw08.hamburg.freifunk.net.
+39			PTR	nat-39-gw08.hamburg.freifunk.net.


### PR DESCRIPTION
Use loopback /32 addresses for everything in order to save broadcast/network addresses.
Those /32 loopback addresses are to be distributed via OSPF.