### PR TITLE
Jabber: srv02 auskommentiert

### DIFF
--- a/master/db.net.ffnord
+++ b/master/db.net.ffnord
@@ -1,7 +1,7 @@
 $ORIGIN ffnord.net.
 $TTL 3600	; 1 Tag
 @			IN SOA	srv01.hamburg.freifunk.net. hostmaster.hamburg.freifunk.net. (
-				2015061500; serial: wird bei jeder Aenderung inkrementiert (Format: JJJJMMDDVV)
+				2015071000; serial: wird bei jeder Aenderung inkrementiert (Format: JJJJMMDDVV)
 				86400	; refresh: Sekundenabstand, in dem die Slaves anfragen, ob sich etwas geändert hat
 				7200	; retry: Sekundenabstand, in denen ein Slave wiederholt, falls sein Master nicht antwortet
 				3600000	; expire: wenn der Master auf einen Zonentransfer-Request nicht reagiert, deaktiviert ein Slave nach dieser Zeitspanne in Sekunden die Zone
@@ -37,13 +37,11 @@ updates	A	193.96.224.250	; srv02.ffhh, dns load balancing
 i	NS	ins.ffnord.net.
 ins	A	144.76.72.235	
 
-conference	A	193.96.224.250		; srv02	
-            	AAAA	2a03:2267:ffff:b00::3	; srv02
-xmpp		A	193.96.224.250		; srv02
-		AAAA	2a03:2267:ffff:b00::3	; srv02
-_xmpp-client._tcp             SRV  10 0 5222 xmpp.ffnord.net.
+; Jabber
+conference	CNAME srv01.hamburg.freifunk.net
+;_xmpp-client._tcp             SRV  10 0 5222 srv02.hamburg.freifunk.net.
 _xmpp-client._tcp             SRV  20 0 5222 srv01.hamburg.freifunk.net.
-_xmpp-server._tcp             SRV  10 0 5269 xmpp.ffnord.net.
+;_xmpp-server._tcp             SRV  10 0 5269 srv02.hamburg.freifunk.net.
 _xmpp-server._tcp             SRV  20 0 5269 srv01.hamburg.freifunk.net.
-_xmpp-server._tcp.conference  SRV  10 0 5269 xmpp.ffnord.net.
+;_xmpp-server._tcp.conference  SRV  10 0 5269 srv02.hamburg.freifunk.net.
 _xmpp-server._tcp.conference  SRV  20 0 5269 srv01.hamburg.freifunk.net.


### PR DESCRIPTION
Ausserdem `xmpp` entfernt, der eigentlich das machen sollte, wofür momentan `conference` herhalten muß.