### PR TITLE
Add zone for ffhh.network

### DIFF
--- a/ffhh.conf
+++ b/ffhh.conf
@@ -12,6 +12,19 @@ zone "ffhh" IN {
     allow-update { key srv01-zone-key.; key srv01-userdomain-key.; };
 };
 
+zone "ffhh.network" IN {
+    type master;
+    allow-transfer {
+        81.7.15.101; # named.exosphere.de
+        144.76.72.235; # ns.ohrensessel.net
+    };
+    also-notify {
+        81.7.15.101; # named.exosphere.de
+        144.76.72.235; # ns.ohrensessel.net
+    };
+    file "/etc/bind/master/db.network.ffhh";
+};
+
 zone "hamburg.freifunk.net" IN {
     type master;
     allow-transfer {

--- a/master/db.network.ffhh
+++ b/master/db.network.ffhh
@@ -1,0 +1,21 @@
+$ORIGIN ffhh.network.
+$TTL 3600
+@ IN SOA srv01.hamburg.freifunk.net. hostmaster.hamburg.freifunk.net. (
+  2016011600 ; serial: wird bei jeder Aenderung inkrementiert (Format: JJJJMMDDVV)
+  86400      ; refresh: Sekundenabstand, in dem die Slaves anfragen, ob sich etwas geändert hat
+  7200       ; retry: Sekundenabstand, in denen ein Slave wiederholt, falls sein Master nicht antwortet
+  3600000    ; expire: wenn der Master auf einen Zonentransfer-Request nicht reagiert, deaktiviert ein Slave nach dieser Zeitspanne in Sekunden die Zone
+  172800     ; TTL fuer negatives caching: Analog zum Standard-Caching wird im Cache vermerkt, dass dem zuständigen Nameserver der Name unbekannt war. Da für einen nicht vorhandenen Namen keine TTL existiert, steht sie hier.
+)
+
+; AUTHORATIVE NAMESERVERS
+@ NS srv01.hamburg.freifunk.net.
+@ NS named.exosphere.de.
+@ NS ns.ohrensessel.net.
+
+; IP of ffhh.network
+@ A    193.96.224.250
+@ AAAA 2a03:2267:ffff:b00::3
+
+; SERVICES
+www        CNAME ffhh.network.


### PR DESCRIPTION
@Entil-Zha  Ich bin wie gesagt kein Bind-Experte (spiele nur einen im Fernsehen), aber das müsste ausreichen, um `ffhh.network` auf denselben Nameservern wie `hamburg.freifunk.net` zu hosten.

@ohrensessel FYI