### PR TITLE
Point "support" subdomain to the new ticket system

### DIFF
--- a/master/db.net.freifunk.hamburg
+++ b/master/db.net.freifunk.hamburg
@@ -1,7 +1,7 @@
 $ORIGIN hamburg.freifunk.net.
 $TTL 3600	; 1 Tag
 @			IN SOA	srv01.hamburg.freifunk.net. hostmaster.hamburg.freifunk.net. (
-				2016020400; serial: wird bei jeder Aenderung inkrementiert (Format: JJJJMMDDVV)
+				2016021400; serial: wird bei jeder Aenderung inkrementiert (Format: JJJJMMDDVV)
 				86400	; refresh: Sekundenabstand, in dem die Slaves anfragen, ob sich etwas geändert hat
 				7200	; retry: Sekundenabstand, in denen ein Slave wiederholt, falls sein Master nicht antwortet
 				3600000	; expire: wenn der Master auf einen Zonentransfer-Request nicht reagiert, deaktiviert ein Slave nach dieser Zeitspanne in Sekunden die Zone
@@ -94,7 +94,7 @@ map			CNAME	srv02
 news			CNAME	srv02
 git                     CNAME   srv01
 ;otr			CNAME   srv02
-support                 CNAME   srv02
+support                 CNAME   ticket.ffhh.pixelkeeper.de.
 ;ldap			CNAME   srv02
 updates			A	212.12.51.134	; srv01, dns load balancing
 			AAAA	2a03:2267::101


### PR DESCRIPTION
The "support" subdomain only redirects to hamburg.freifunk.net at the moment. If that subdomain isn't actively used in another context and if it's fine with you, I would like to point it to the ticket system which we intend to use.