### PR TITLE
kontakt.hamburg.freifunk.net für das Ticketsystem

### DIFF
--- a/master/db.net.freifunk.hamburg
+++ b/master/db.net.freifunk.hamburg
@@ -1,7 +1,7 @@
 $ORIGIN hamburg.freifunk.net.
 $TTL 3600	; 1 Tag
 @			IN SOA	srv01.hamburg.freifunk.net. hostmaster.hamburg.freifunk.net. (
-				2016020400; serial: wird bei jeder Aenderung inkrementiert (Format: JJJJMMDDVV)
+				2016021400; serial: wird bei jeder Aenderung inkrementiert (Format: JJJJMMDDVV)
 				86400	; refresh: Sekundenabstand, in dem die Slaves anfragen, ob sich etwas geändert hat
 				7200	; retry: Sekundenabstand, in denen ein Slave wiederholt, falls sein Master nicht antwortet
 				3600000	; expire: wenn der Master auf einen Zonentransfer-Request nicht reagiert, deaktiviert ein Slave nach dieser Zeitspanne in Sekunden die Zone
@@ -94,7 +94,7 @@ map			CNAME	srv02
 news			CNAME	srv02
 git                     CNAME   srv01
 ;otr			CNAME   srv02
-support                 CNAME   srv02
+support                 CNAME   ticket.ffhh.pixelkeeper.de.
 ;ldap			CNAME   srv02
 updates			A	212.12.51.134	; srv01, dns load balancing
 			AAAA	2a03:2267::101

--- a/master/db.net.freifunk.hamburg
+++ b/master/db.net.freifunk.hamburg
@@ -1,7 +1,7 @@
 $ORIGIN hamburg.freifunk.net.
 $TTL 3600	; 1 Tag
 @			IN SOA	srv01.hamburg.freifunk.net. hostmaster.hamburg.freifunk.net. (
-				2016021400; serial: wird bei jeder Aenderung inkrementiert (Format: JJJJMMDDVV)
+				2016021600; serial: wird bei jeder Aenderung inkrementiert (Format: JJJJMMDDVV)
 				86400	; refresh: Sekundenabstand, in dem die Slaves anfragen, ob sich etwas geändert hat
 				7200	; retry: Sekundenabstand, in denen ein Slave wiederholt, falls sein Master nicht antwortet
 				3600000	; expire: wenn der Master auf einen Zonentransfer-Request nicht reagiert, deaktiviert ein Slave nach dieser Zeitspanne in Sekunden die Zone
@@ -94,7 +94,8 @@ map			CNAME	srv02
 news			CNAME	srv02
 git                     CNAME   srv01
 ;otr			CNAME   srv02
-support                 CNAME   ticket.ffhh.pixelkeeper.de.
+support			CNAME   srv02
+kontakt			CNAME	ticket.ffhh.pixelkeeper.de.
 ;ldap			CNAME   srv02
 updates			A	212.12.51.134	; srv01, dns load balancing
 			AAAA	2a03:2267::101


### PR DESCRIPTION
Wir haben uns Montag Abend den aktuellen Stand des Ticketsystems angeschaut und uns auf die Subdomain `kontakt.` geeinigt. Damit vermittelt Freifunk am wenigsten den Eindruck eines kommerziellen Angebots. Die ursprünglich von mir vorgeschlagene Subdomain `support.` habe ich auf den vorigen Stand zurückgesetzt. Falls sie nicht anderweitig verwendet wird, schlage ich vor sie zu löschen.