### PR TITLE
Move formular.helgoland.freifunk.net

### DIFF
--- a/master/db.net.freifunk.helgoland
+++ b/master/db.net.freifunk.helgoland
@@ -1,7 +1,7 @@
 $ORIGIN helgoland.freifunk.net.
 $TTL 3600	; 1 Tag
 @			IN SOA	srv01.hamburg.freifunk.net. hostmaster.hamburg.freifunk.net. (
-				2016041200; serial: wird bei jeder Aenderung inkrementiert (Format: JJJJMMDDVV)
+				2017012600; serial: wird bei jeder Aenderung inkrementiert (Format: JJJJMMDDVV)
 				86400	; refresh: Sekundenabstand, in dem die Slaves anfragen, ob sich etwas geändert hat
 				7200	; retry: Sekundenabstand, in denen ein Slave wiederholt, falls sein Master nicht antwortet
 				3600000	; expire: wenn der Master auf einen Zonentransfer-Request nicht reagiert, deaktiviert ein Slave nach dieser Zeitspanne in Sekunden die Zone
@@ -34,8 +34,7 @@ updates		A	212.12.51.134	; srv01.ffhh, dns load balancing
 		AAAA	2a03:2267::101
 updates		A	193.96.224.250	; srv02.ffhh, dns load balancing
 		AAAA    2a03:2267:ffff:b00::3
-formular	A	212.12.51.134	; srv01.ffhh
-		AAAA	2a03:2267::101
+formular	CNAME	srv01
 karte		CNAME	srv01
 meta		CNAME 	srv01
 git		CNAME	srv01


### PR DESCRIPTION
Move formular.helgoland.freifunk.net to srv01.helgoland.freifunk.net host.